### PR TITLE
Add scaffolding and setup.py file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,66 @@
+# Charm specific
+build/
+*.charm
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/_build/
+
+# PEP 582
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mkdocs documentation
+/site

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# hpct-editors
+
+> This repository is currently a work-in-progress.

--- a/lib/hpcteditors/app/slurm.py
+++ b/lib/hpcteditors/app/slurm.py
@@ -4,9 +4,8 @@
 # hpcteditors/app/slurm.py
 
 
-from ..lib.base import EOF, ParsingError, Matcher, RecordNode, StringNode
-from ..lib.line import LineParser, LineEditor, LinesNode
-
+from ..lib.base import EOF, Matcher, ParsingError, RecordNode, StringNode
+from ..lib.line import LineEditor, LineParser, LinesNode
 
 # simple class definitions
 CommentNode = type("CommentNode", (StringNode,), {})

--- a/lib/hpcteditors/app/slurm.py
+++ b/lib/hpcteditors/app/slurm.py
@@ -155,3 +155,8 @@ class SlurmConfFileEditor(LineEditor):
         """Convenience: Add line."""
         p = self.get_parser(line)
         self.root.add(p.parse_slurmrecord())
+
+    def add_lines(self, lines):
+        for line in lines:
+            p = self.get_parser(line)
+            self.root.add(p.parse_slurmrecord())

--- a/lib/hpcteditors/lib/line/parser.py
+++ b/lib/hpcteditors/lib/line/parser.py
@@ -4,8 +4,8 @@
 # hpcteditors/base/line/parser.py
 
 
-from .node import BlankLineNode, CommentLineNode, LineNode, LinesNode
 from ..base import EOF, Parser
+from .node import BlankLineNode, CommentLineNode, LineNode, LinesNode
 
 
 class LineParser(Parser):

--- a/lib/hpcteditors/os/exports.py
+++ b/lib/hpcteditors/os/exports.py
@@ -8,17 +8,16 @@ import re
 
 from ..lib.base import (
     EOF,
-    ParsingError,
-    remove_child_nodes,
     CommaJoinNode,
     ContainerNode,
+    ParentOfMatcher,
+    ParsingError,
     RecordNode,
     StringNode,
-    ParentOfMatcher,
     TypeValueMatcher,
+    remove_child_nodes,
 )
-from ..lib.line import LineEditor, LineParser, BlankLineNode, CommentLineNode, LinesNode
-
+from ..lib.line import BlankLineNode, CommentLineNode, LineEditor, LineParser, LinesNode
 
 CLIENTOPTIONS_RE = r"""(?P<client>[^(]+)(\((?P<options>[a-zA-Z0-9_,"]+)\))?"""
 

--- a/lib/hpcteditors/os/freedesktop.py
+++ b/lib/hpcteditors/os/freedesktop.py
@@ -6,18 +6,17 @@
 
 from ..lib.base import (
     EOF,
-    ParsingError,
-    remove_child_nodes,
     Matcher,
     ParentOfMatcher,
-    TypeMatcher,
-    TypeValueMatcher,
+    ParsingError,
     RecordNode,
     StringNode,
     TemplateStringNode,
+    TypeMatcher,
+    TypeValueMatcher,
+    remove_child_nodes,
 )
-from ..lib.line import LineEditor, LineParser, BlankLineNode, CommentLineNode, LinesNode
-
+from ..lib.line import BlankLineNode, CommentLineNode, LineEditor, LineParser, LinesNode
 
 # simple class definitions
 EntriesNode = type("EntriesNode", (RecordNode,), {"separator": "\n"})

--- a/lib/hpcteditors/os/fstab.py
+++ b/lib/hpcteditors/os/fstab.py
@@ -6,15 +6,14 @@
 
 from ..lib.base import (
     EOF,
-    ParsingError,
-    remove_child_nodes,
     ParentOfMatcher,
-    TypeValueMatcher,
+    ParsingError,
     RecordNode,
     StringNode,
+    TypeValueMatcher,
+    remove_child_nodes,
 )
-from ..lib.line import LineEditor, LineParser, BlankLineNode, CommentLineNode, LinesNode
-
+from ..lib.line import BlankLineNode, CommentLineNode, LineEditor, LineParser, LinesNode
 
 # simple class definitions
 FileNode = type("FileNode", (StringNode,), {})

--- a/lib/hpcteditors/os/nsswitch.py
+++ b/lib/hpcteditors/os/nsswitch.py
@@ -6,17 +6,16 @@
 
 from ..lib.base import (
     EOF,
-    ParsingError,
     ContainerNode,
+    ParentOfMatcher,
+    ParsingError,
     RecordNode,
     StringNode,
     TemplateStringNode,
-    ParentOfMatcher,
     TypeMatcher,
     TypeValueMatcher,
 )
-from ..lib.line import LineEditor, LineParser, BlankLineNode, CommentLineNode, LinesNode
-
+from ..lib.line import BlankLineNode, CommentLineNode, LineEditor, LineParser, LinesNode
 
 # simple class definitions
 ActionNode = type("ActionNode", (TemplateStringNode,), {"template": "[{value}]"})

--- a/lib/hpcteditors/os/systemd.py
+++ b/lib/hpcteditors/os/systemd.py
@@ -6,17 +6,16 @@
 
 from ..lib.base import (
     EOF,
-    ParsingError,
-    remove_child_nodes,
     ParentOfMatcher,
-    TypeMatcher,
-    TypeValueMatcher,
+    ParsingError,
     RecordNode,
     StringNode,
     TemplateStringNode,
+    TypeMatcher,
+    TypeValueMatcher,
+    remove_child_nodes,
 )
-from ..lib.line import LineEditor, LineParser, BlankLineNode, CommentLineNode, LinesNode
-
+from ..lib.line import BlankLineNode, CommentLineNode, LineEditor, LineParser, LinesNode
 
 HeaderNode = type("HeaderNode", (TemplateStringNode,), {"template": "[{value}]"})
 NameNode = type("NameNode", (StringNode,), {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+line_length = 99
+profile = "black"
+
+# Linting tools configuration
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "__init__.py"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
+docstring-convention = "google"
+# Check for properly formatted copyright header in each file
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from setuptools import setup, find_packages
+
+
+setup(
+    name="hpcteditors",
+    version="0.1.0",
+    description="Configuration file editors for common applications in HPC.",
+    license="Apache-2.0",
+    packages=find_packages(where="lib", include=["hpcteditors*"]),
+    package_dir={"": "lib"},
+)

--- a/tests/exports_test/exports_test.py
+++ b/tests/exports_test/exports_test.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath("../../lib"))
 
 from hpcteditors.os.exports import ExportsFileEditor
 
-
 if __name__ == "__main__":
     sep = "----------"
 

--- a/tests/freedesktop_test/freedesktop_test.py
+++ b/tests/freedesktop_test/freedesktop_test.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath("../../lib"))
 
 from hpcteditors.os.freedesktop import FreeDesktopConfFileEditor
 
-
 if __name__ == "__main__":
     sep = "----------"
 

--- a/tests/nsswitch_test/nsswitch_test.py
+++ b/tests/nsswitch_test/nsswitch_test.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath("../../lib"))
 
 from hpcteditors.os.nsswitch import NSSwitchConfFileEditor
 
-
 if __name__ == "__main__":
     sep = "----------"
 

--- a/tests/slurm_test/slurm_test.py
+++ b/tests/slurm_test/slurm_test.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath("../../lib"))
 
 from hpcteditors.app.slurm import SlurmConfFileEditor
 
-
 if __name__ == "__main__":
     sep = "----------"
 

--- a/tests/systemd_test/systemd_test.py
+++ b/tests/systemd_test/systemd_test.py
@@ -11,7 +11,6 @@ sys.path.insert(0, os.path.realpath("../../lib"))
 
 from hpcteditors.os.systemd import SystemdConfFileEditor
 
-
 if __name__ == "__main__":
     sep = "----------"
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 envlist = lint
 
 [vars]
-src_path = {toxinidir}/src/
+src_path = {toxinidir}/lib/
 tst_path = {toxinidir}/tests/
 all_path = {[vars]src_path} {[vars]tst_path} 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,52 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+[tox]
+skipsdist=True
+skip_missing_interpreters = True
+envlist = lint
+
+[vars]
+src_path = {toxinidir}/src/
+tst_path = {toxinidir}/tests/
+all_path = {[vars]src_path} {[vars]tst_path} 
+
+[testenv]
+setenv =
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+  PYTHONBREAKPOINT=ipdb.set_trace
+  PY_COLORS=1
+passenv =
+  PYTHONPATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+  black
+  isort
+commands =
+  isort {[vars]all_path}
+  black {[vars]all_path}
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+  black
+  flake8
+  flake8-docstrings
+  flake8-copyright
+  flake8-builtins
+  pyproject-flake8
+  pep8-naming
+  isort
+  codespell
+commands =
+  codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
+    --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+  # pflake8 wrapper supports config from pyproject.toml
+  pflake8 {[vars]all_path}
+  isort --check-only --diff {[vars]all_path}
+  black --check --diff {[vars]all_path}


### PR DESCRIPTION
This pull request aims to add some new files and functionality to the project:

* `README.md` - Template README for feature documentation such as where to get documentation.
* `.gitignore` - To prevent any pycache, build artifacts, etc. from working their way into commits.
* `pyproject.toml` and `tox.ini` - Tox environments for formatting and linting library code. Can also expand out to publishing, doc serving, and functional/unit/smoke tests.
* `requirements.txt` - So others can replicate the development environment.
* `setup.py` - Allows us to pull the package from GitHub and/or upload to PyPI at a later date.

### Misc

* I added an `add_lines` method to the SLURM configuration file editor. Instead of going string by string, you can just pass a list of strings for a bulk addition.